### PR TITLE
[test] Owner에 대한 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/main/java/com/payhere/owner/dto/SignupRequest.java
+++ b/src/main/java/com/payhere/owner/dto/SignupRequest.java
@@ -1,5 +1,6 @@
 package com.payhere.owner.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -11,6 +12,7 @@ public class SignupRequest {
     protected SignupRequest() {
     }
 
+    @Builder
     public SignupRequest(final String cellPhoneNumber, final String password) {
         this.cellPhoneNumber = cellPhoneNumber;
         this.password = password;

--- a/src/main/java/com/payhere/owner/presentation/OwnerController.java
+++ b/src/main/java/com/payhere/owner/presentation/OwnerController.java
@@ -20,8 +20,9 @@ public class OwnerController {
     }
 
     @PostMapping("/signup")
-    public ApiResponse<Long> signUp(@Valid @RequestBody SignupRequest signupRequest) {
+    public ResponseEntity<ApiResponse<Long>> signUp(@Valid @RequestBody final SignupRequest signupRequest) {
         Long ownerId =  ownerService.signUp(signupRequest);
-        return ApiResponse.created(ownerId);
+        ApiResponse<Long> apiResponse = ApiResponse.created(ownerId);
+        return new ResponseEntity<>(apiResponse, HttpStatus.CREATED);
     }
 }

--- a/src/test/java/com/payhere/owner/domain/PasswordTest.java
+++ b/src/test/java/com/payhere/owner/domain/PasswordTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class PasswordTest {
@@ -21,7 +22,7 @@ class PasswordTest {
         HashingI hashing = new HashingFactory().getHashing();
 
         // when & then
-        Assertions.assertThatThrownBy(() -> Password.of(hashing, invalidPassword))
+        assertThatThrownBy(() -> Password.of(hashing, invalidPassword))
                 .isInstanceOf(InvalidPasswordFormatException.class);
     }
 

--- a/src/test/java/com/payhere/owner/presentation/OwnerControllerTest.java
+++ b/src/test/java/com/payhere/owner/presentation/OwnerControllerTest.java
@@ -1,0 +1,62 @@
+package com.payhere.owner.presentation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.payhere.auth.application.AuthService;
+import com.payhere.owner.application.OwnerService;
+import com.payhere.owner.dto.SignupRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.payhere.common.fixtures.OwnerFixtures.사장님_비밀번호;
+import static com.payhere.common.fixtures.OwnerFixtures.사장님_휴대폰_번호;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({
+        OwnerController.class
+})
+@ActiveProfiles("test")
+class OwnerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private OwnerService ownerService;
+
+    @MockBean
+    private AuthService authService;
+
+    @DisplayName("사장님은 시스템에 휴대폰 번호와 비밀번호 입력을 통해서 회원가입을 할 수 있다.")
+    @Test
+    void signUp() throws Exception {
+        // given
+        SignupRequest request = SignupRequest.builder()
+                .cellPhoneNumber(사장님_휴대폰_번호)
+                .password(사장님_비밀번호)
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/owners/signup")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isCreated());
+    }
+
+}


### PR DESCRIPTION
- [x] 🙆🏻 PR 제목 형식은 지켰는가? ex. `[feat] 상품 등록 기능을 구현한다. `
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `기능`, `리팩터링`

## 작업 내용

- Owner에 대한 컨트롤러 테스트 코드를 작성했습니다.
- 이전 Product에 대한 컨트롤러 테스트 코드와 마찬가지로, 실제 HTTP 응답 상태 코드와 일치하기 위해 기존 로직에서 `ApiResponse` 객체를 `ResponseEntity`와 함께 사용하는 걸로 수정했습니다.

## 주의사항

Closes #33
